### PR TITLE
Appstream validation, new url

### DIFF
--- a/data/edu.stanford.Almond.appdata.xml.in
+++ b/data/edu.stanford.Almond.appdata.xml.in
@@ -12,13 +12,14 @@
     Thingpedia supports more than 50 different services, accounts and IoT devices.</p>
   </description>
   <screenshots>
-    <screenshot type="default" width="640" height="527">https://crowdie.stanford.edu/flatpak/screenshot-main.png</screenshot>
-    <screenshot width="1720" height="1232">https://crowdie.stanford.edu/flatpak/screenshot-xkcd.png</screenshot>
-    <screenshot width="1800" height="1072">https://crowdie.stanford.edu/flatpak/screenshot-nytimes.png</screenshot>
-    <screenshot width="1800" height="1158">https://crowdie.stanford.edu/flatpak/screenshot-my-goods.png</screenshot>
-    <screenshot width="1984" height="1166">https://crowdie.stanford.edu/flatpak/screenshot-my-rules.png</screenshot>
+    <screenshot type="default"><image width="640" height="527">https://crowdie.stanford.edu/flatpak/screenshot-main.png</image></screenshot>
+    <screenshot><image width="1720" height="1232">https://crowdie.stanford.edu/flatpak/screenshot-xkcd.png</image></screenshot>
+    <screenshot><image width="1800" height="1072">https://crowdie.stanford.edu/flatpak/screenshot-nytimes.png</image></screenshot>
+    <screenshot><image width="1800" height="1158">https://crowdie.stanford.edu/flatpak/screenshot-my-goods.png</image></screenshot>
+    <screenshot><image width="1984" height="1166">https://crowdie.stanford.edu/flatpak/screenshot-my-rules.png</image></screenshot>
   </screenshots>
   <url type="homepage">https://almond.stanford.edu</url>
+  <url type="bugtracker">https://github.com/Stanford-Mobisocial-IoT-Lab/almond-gnome/issues</url>
   <releases>
     <release date="2018-06-16" version="1.0.0">
       <description>


### PR DESCRIPTION
+ Appstream validation failed because every <screenshot/> tag must have at least one <image/> child. Fixed.
+ Added a url for the bugtracker